### PR TITLE
Refactor extractor to use configurable relnotes URL

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -33,3 +33,4 @@ urls:
   uniprot_ftp_base_url: "https://ftp.uniprot.org/pub/databases/uniprot/current_release/knowledgebase/complete/"
   release_notes_filename: "reldate.txt"
   checksums_filename: "MD5SUMS"
+  relnotes_url: "https://ftp.uniprot.org/pub/databases/uniprot/current_release/relnotes.txt"

--- a/src/py_load_uniprot/__init__.py
+++ b/src/py_load_uniprot/__init__.py
@@ -8,5 +8,6 @@ __version__ = "1.0.0"
 
 from .config import Settings, load_settings
 from .core import PyLoadUniprotPipeline
+from .db_manager import DatabaseAdapter
 
-__all__ = ["PyLoadUniprotPipeline", "Settings", "load_settings"]
+__all__ = ["PyLoadUniprotPipeline", "Settings", "load_settings", "DatabaseAdapter"]

--- a/src/py_load_uniprot/config.py
+++ b/src/py_load_uniprot/config.py
@@ -29,6 +29,7 @@ class URLSettings(BaseModel):
     )
     release_notes_filename: str = "reldate.txt"
     checksums_filename: str = "MD5SUMS"
+    relnotes_url: str = "https://ftp.uniprot.org/pub/databases/uniprot/current_release/relnotes.txt"
 
 
 class Settings(BaseSettings):

--- a/src/py_load_uniprot/extractor.py
+++ b/src/py_load_uniprot/extractor.py
@@ -249,9 +249,7 @@ class Extractor:
             raise
 
         # --- Get Entry Counts from relnotes.txt ---
-        relnotes_url = (
-            "https://ftp.uniprot.org/pub/databases/uniprot/current_release/relnotes.txt"
-        )
+        relnotes_url = self.settings.urls.relnotes_url
         print(f"Fetching statistics from {relnotes_url}")
         try:
             response = self.session.get(relnotes_url)


### PR DESCRIPTION
The URL for the UniProt `relnotes.txt` file was previously hardcoded in the extractor module. This change moves the URL to the `URLSettings` model in `config.py`, making it configurable via YAML or environment variables. This aligns with the FRD's requirement for all external endpoints to be configurable.

Expose DatabaseAdapter in the public API

The `DatabaseAdapter` abstract base class is a key component for the package's extensibility. This change exposes it in the top-level `__init__.py`, making it part of the public API. This allows developers to easily import it (`from py_load_uniprot import DatabaseAdapter`) to create their own custom adapters for other database systems, fulfilling a core architectural goal of the FRD.