### PR TITLE
Fix linting errors (#59)

### DIFF
--- a/src/py_load_uniprot/transformer.py
+++ b/src/py_load_uniprot/transformer.py
@@ -355,7 +355,6 @@ def _transform_single_threaded(xml_file: Path, output_dir: Path, profile: str) -
     # Sets for de-duplication
     seen_taxonomy_ids: set[int] = set()
     seen_protein_accessions: set[str] = set()
-    duplicate_accessions: set[str] = set()
 
     with (
         FileWriterManager(output_dir) as writers,

--- a/tests/test_cli_errors.py
+++ b/tests/test_cli_errors.py
@@ -1,7 +1,6 @@
 from unittest.mock import MagicMock, patch
 
 from typer.testing import CliRunner
-import pytest
 
 from py_load_uniprot.cli import app
 

--- a/tests/test_extractor_coverage.py
+++ b/tests/test_extractor_coverage.py
@@ -1,4 +1,3 @@
-import datetime
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,7 +1,6 @@
 import datetime
 import gzip
 import json
-import logging
 from pathlib import Path
 
 import psycopg2

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1,5 +1,4 @@
 import gzip
-import os
 import tracemalloc
 from pathlib import Path
 


### PR DESCRIPTION
This commit fixes several linting errors that were causing the GitHub Actions to fail.

The following errors were fixed:
- Unused local variable `duplicate_accessions` in `src/py_load_uniprot/transformer.py`.
- Unused imports in `tests/test_cli_errors.py`, `tests/test_extractor_coverage.py`, `tests/test_integration.py`, and `tests/test_memory.py`.
- Unsorted imports in `tests/test_cli_errors.py`.

All linting checks and tests now pass.